### PR TITLE
bugfix: changed created from string to array

### DIFF
--- a/src/Domain/AccountHolder.php
+++ b/src/Domain/AccountHolder.php
@@ -50,7 +50,8 @@ final class AccountHolder implements DomainObjectInterface
 
     public int $storageBytesUsed;
 
-    public ?string $created;
+    /** @var array<mixed>|null */
+    public ?array $created;
 
     public ?string $lastLogin;
 
@@ -59,32 +60,32 @@ final class AccountHolder implements DomainObjectInterface
     /**
      * AccountHolder constructor.
      *
-     * @param int          $ref
-     * @param string       $firstName
-     * @param string       $lastName
-     * @param string       $username
-     * @param string       $email
-     * @param int          $suspended
-     * @param bool         $beta
-     * @param string       $languageCode
-     * @param int|null     $phoneNumber
-     * @param string|null  $address1
-     * @param string|null  $address2
-     * @param string|null  $city
-     * @param string|null  $postcode
-     * @param string|null  $country
-     * @param int          $newsletter
-     * @param int          $currencyRef
-     * @param string|null  $state
-     * @param Capabilities $capabilities
-     * @param int|null     $accountPaymentMethodRef
-     * @param int|null     $cpfNumber
-     * @param int          $cpfCompany
-     * @param bool         $deleted
-     * @param int          $storageBytesUsed
-     * @param string|null  $created
-     * @param string|null  $lastLogin
-     * @param string       $accountStatus
+     * @param int               $ref
+     * @param string            $firstName
+     * @param string            $lastName
+     * @param string            $username
+     * @param string            $email
+     * @param int               $suspended
+     * @param bool              $beta
+     * @param string            $languageCode
+     * @param int|null          $phoneNumber
+     * @param string|null       $address1
+     * @param string|null       $address2
+     * @param string|null       $city
+     * @param string|null       $postcode
+     * @param string|null       $country
+     * @param int               $newsletter
+     * @param int               $currencyRef
+     * @param string|null       $state
+     * @param Capabilities      $capabilities
+     * @param int|null          $accountPaymentMethodRef
+     * @param int|null          $cpfNumber
+     * @param int               $cpfCompany
+     * @param bool              $deleted
+     * @param int               $storageBytesUsed
+     * @param array<mixed>|null $created
+     * @param string|null       $lastLogin
+     * @param string            $accountStatus
      */
     public function __construct(
         int $ref,
@@ -110,7 +111,7 @@ final class AccountHolder implements DomainObjectInterface
         int $cpfCompany,
         bool $deleted,
         int $storageBytesUsed,
-        ?string $created,
+        ?array $created,
         ?string $lastLogin,
         string $accountStatus
     ) {


### PR DESCRIPTION
This was an error that accured when creating an accountHolder.

Created is a null or an array. We had string or null